### PR TITLE
Atualizar CI para usar o Antigravity Kit oficial

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
       if: failure()
       run: |
         echo "Acordando o subagent de correção..."
-        curl -X POST "${{ secrets.OPENCLAW_WEBHOOK_URL }}" \
+        curl -X POST "https://openclaw.marcuslinhares.com/hooks/ci_failure" \
+          -H "Authorization: Bearer ${{ secrets.OPENCLAW_WEBHOOK_TOKEN }}" \
           -H "Content-Type: application/json" \
           -d '{"event": "ci_failure", "repo": "${{ github.repository }}", "branch": "${{ github.ref_name }}", "run_id": "${{ github.run_id }}"}'
 


### PR DESCRIPTION
Conforme a nova regra estabelecida, este PR modifica o workflow para clonar e utilizar os scripts originais direto de `vudovn/antigravity-kit`, apagando o diretório local `.agent` durante a execução do CI.