### PR TITLE
[CI FIX] Remove test type error from page.tsx

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,9 +7,6 @@ import type { Metadata } from 'next'
 
 export const revalidate = 0 // Atualiza sempre que entrar (sem cache velho)
 
-// INTENTIONAL ERROR FOR TESTING
-const testError: string = 42; // Type mismatch
-
 export const metadata: Metadata = {
   title: 'Ofertas do Dia | Mercadinho Connect',
   description: 'Confira as melhores ofertas e promoções do mercadinho do bairro! Produtos frescos com preços imperdíveis.',


### PR DESCRIPTION
Resolves lint failure caused by unused variable `testError`. This was added for testing the ci-fixer automation.